### PR TITLE
Simplify build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
 intellij {
     pluginName.set(properties("pluginName"))
     version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
     downloadSources.set(properties("platformDownloadSources").toBoolean())
     updateSinceUntilBuild.set(true)
     /* When we are ready to work with makefile support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ tasks {
         val pluginVersion = properties("pluginVersion")
         version.set(pluginVersion)
         sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
+        untilBuild.set("")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ pluginGroup = com.github.nthykier.debpkg
 pluginName = debpkg
 pluginVersion = 0.0.22
 pluginSinceBuild = 212
-pluginUntilBuild = 233.*
 
 # Reminder: Must be aligned with `pluginSinceBuild` to ensure backwards
 # compat work properly (https://github.com/JetBrains/gradle-intellij-plugin/issues/1440)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ pluginVersion = 0.0.22
 pluginSinceBuild = 212
 pluginUntilBuild = 233.*
 
-platformType = IC
 # Reminder: Must be aligned with `pluginSinceBuild` to ensure backwards
 # compat work properly (https://github.com/JetBrains/gradle-intellij-plugin/issues/1440)
 platformVersion = 2021.2


### PR DESCRIPTION
Set untilBuild to "" to avoid need for always update the plugin when a new version comes.
I wasn't able o see the plugin in CLion 2024.1 marketplace and hope this changes may help.
In the Idea EAP 2023.3 I do see the plugin in the marketplace so I believe this is related to the until build.